### PR TITLE
Removing fixed width of cards

### DIFF
--- a/lib/custom-ui/components/drawer/layers-list/draggableCards.js
+++ b/lib/custom-ui/components/drawer/layers-list/draggableCards.js
@@ -15,7 +15,7 @@ const StyledLi = styled(Li)`
   color: ${"black"};
   border-radius: 4px;
   margin-bottom: 5px;
-  width: 100%;
+  //width: 100%;
 `;
 
 function DraggableCard(props) {

--- a/lib/custom-ui/components/drawer/layers-list/layer-card.js
+++ b/lib/custom-ui/components/drawer/layers-list/layer-card.js
@@ -165,7 +165,7 @@ export const LayerCard = ({
   return (
     <Card
       sx={{
-        width: "325px",
+        // width: "325px",
         backgroundColor: currentlyActive ? "white" : "darkgrey",
         color: currentlyActive ? "#000c" : "#fffc",
         transition: "background-color 250ms, color 500ms",


### PR DESCRIPTION
it would appear that the default vertical scroll bar width in firefox is a little wider than other browsers. so when that scrollbar appears it overlaps the card causing a horizontal scrollbar.

the fix was to remove the hard-coded card width (325px) to let the card fill 100% of the available area.

this fix is in reference to issue #65.